### PR TITLE
FrontendDeployment: add Dockerfile templates

### DIFF
--- a/frontend.md
+++ b/frontend.md
@@ -36,3 +36,46 @@ TBD.
 * [VueJs](https://vuejs.org/v2/style-guide/)
 * [VuePress](https://vuepress.vuejs.org/)
 * [Gridsome](https://gridsome.org/)
+
+## Dockerfile Template
+
+### Static Hosting
+- VueCLI
+  ```dockerfile
+  # build VueJS app
+  FROM      node:10.16-alpine as build-stage
+  RUN       mkdir /app
+  WORKDIR   /app
+  COPY      . .
+  RUN       npm install --progress=false
+  RUN       npm run build
+
+  # use nginx to serve built files from previous stage
+  FROM      nginx:stable-alpine as production
+  COPY      --from=build-stage /app/dist /usr/share/nginx/html
+  EXPOSE    80
+  CMD       ["nginx", "-g", "daemon off;"]
+  ```
+
+### Server-Side Rendering
+- NuxtJS
+  To enable SSR, use `mode: 'universal'` and `target: 'server'` in `nuxt.config.js`.
+  ```dockerfile
+  FROM node:latest
+  WORKDIR /app
+  COPY . .
+
+  # ENV HOST must be exactly set as 0.0.0.0 (https://nuxtjs.org/faq/host-port/)
+  ENV HOST 0.0.0.0
+
+  # ENV PORT and EXPOSE value must be equal
+  ENV PORT 3000
+
+  RUN npm install
+  RUN npm run build
+
+  EXPOSE 3000
+
+  # run nuxt as node http server instance
+  CMD [ "npm", "run", "start" ]
+  ```


### PR DESCRIPTION
Add Dockerfile template for:
- Static hosting (normally used on VueJS apps)
- Server-Side Rendering (supported by NuxtJS SSR mode)